### PR TITLE
feat: Update default value for serviceName parameter in azure-pipelin…

### DIFF
--- a/YAML/azure-pipeline.yml
+++ b/YAML/azure-pipeline.yml
@@ -26,7 +26,7 @@ parameters:
         authenticationType: 'servicePrincipal'
   - name: serviceName
     type: string
-    default: 'sqlmoveemecicd'
+    default: 'bicepaadentra'
   - name: artifactsToPublish
     type: object
     default: ['security', 'infrastructure']


### PR DESCRIPTION
This pull request includes a small change to the `YAML/azure-pipeline.yml` file. The change updates the default value of the `serviceName` parameter.

* [`YAML/azure-pipeline.yml`](diffhunk://#diff-ca50b8d493b3a8b1cbaedcda350f8f5f0297c4944d33e568a0f9cfb1373b9dafL29-R29): Changed the default value of the `serviceName` parameter from `'sqlmoveemecicd'` to `'bicepaadentra'`.…e.yml