### PR TITLE
feat: Update SQL server and resource group names in azure-pipeline.yml

### DIFF
--- a/YAML/azure-pipeline.yml
+++ b/YAML/azure-pipeline.yml
@@ -18,9 +18,9 @@ parameters:
         regionAbrvs: ['eus']
         projectExtension: '.sqlproj'
         buildArguments: '/p:NetCoreBuild=true'
-        sqlServerName: 'moveme'
+        sqlServerName: 'bicepaadentra'
         sqlDatabaseName: 'moveme'
-        resourceGroupName: sqlserver
+        resourceGroupName: bicepaadentra
         ipDetectionMethod: 'AutoDetect'
         deployType: 'DacpacTask'
         authenticationType: 'servicePrincipal'


### PR DESCRIPTION
This pull request includes changes to the `YAML/azure-pipeline.yml` file to update several parameter values.

Parameter updates:

* [`sqlServerName`](diffhunk://#diff-ca50b8d493b3a8b1cbaedcda350f8f5f0297c4944d33e568a0f9cfb1373b9dafL21-R23): Changed from `'moveme'` to `'bicepaadentra'` (`YAML/azure-pipeline.yml`)
* [`resourceGroupName`](diffhunk://#diff-ca50b8d493b3a8b1cbaedcda350f8f5f0297c4944d33e568a0f9cfb1373b9dafL21-R23): Changed from `sqlserver` to `bicepaadentra` (`YAML/azure-pipeline.yml`)